### PR TITLE
Feat/#3 todo 생성 조회 수정 삭제 api 구현

### DIFF
--- a/http/todo.http
+++ b/http/todo.http
@@ -1,0 +1,16 @@
+### Todo 목록 조회
+GET localhost:8080/todos
+
+###
+POST localhost:8080/todos
+Content-Type: application/json
+
+{
+  "content": "오늘 할 일은 밥먹기"
+}
+
+###
+PATCH localhost:8080/todos/1
+
+###
+DELETE localhost:8080/todos/1

--- a/src/main/java/boardcafe/boardpractice/common/cors/CorsConfig.java
+++ b/src/main/java/boardcafe/boardpractice/common/cors/CorsConfig.java
@@ -1,0 +1,18 @@
+package boardcafe.boardpractice.common.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://ssafysandbox.vercel.app")
+                .allowCredentials(true)
+                .allowedMethods("*")
+                .exposedHeaders("*");
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/exception/ErrorCode.java
+++ b/src/main/java/boardcafe/boardpractice/common/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     EXPIRED_ACCESS_TOKEN(2005, UNAUTHORIZED, "만료된 AccessToken 입니다."),
     EXPIRED_REFRESH_TOKEN(2006, UNAUTHORIZED, "만료된 RefreshToken 입니다."),
 
-    NOT_FOUND_BOARD_ID(3001, NOT_FOUND, "요청한 ID에 해당하는 게시물이 존재하지 않습니다."),
+    NOT_FOUND_TODO_ID(3001, NOT_FOUND, "요청한 ID에 해당하는 게시물이 존재하지 않습니다."),
     NOT_FOUND_USER_ID(3002, NOT_FOUND, "요청한 ID에 해당하는 사용자가 존재하지 않습니다."),
     NOT_FOUND_USER_EMAIL(3003, NOT_FOUND, "요청한 이메일에 해당하는 사용자가 존재하지 않습니다."),
     NOT_FOUND_IMAGE_FILE(3004, NOT_FOUND, "요청한 이미지 파일을 찾을 수 없습니다."),

--- a/src/main/java/boardcafe/boardpractice/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/boardcafe/boardpractice/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package boardcafe.boardpractice.common.exception;
 
+import boardcafe.boardpractice.todo.exception.TodoNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -13,6 +15,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import static boardcafe.boardpractice.common.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @RestControllerAdvice
@@ -29,6 +32,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String errorMessage = e.getBindingResult().getAllErrors().getFirst().getDefaultMessage();
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(INVALID_REQUEST, errorMessage));
+    }
+
+    @ExceptionHandler(TodoNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleTodoNotFoundException(final TodoNotFoundException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.status(NOT_FOUND)
+                .body(new ExceptionResponse(e.getErrorCode()));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/boardcafe/boardpractice/todo/application/TodoService.java
+++ b/src/main/java/boardcafe/boardpractice/todo/application/TodoService.java
@@ -1,0 +1,51 @@
+package boardcafe.boardpractice.todo.application;
+
+import boardcafe.boardpractice.todo.application.request.TodoCreateServiceRequest;
+import boardcafe.boardpractice.todo.application.response.TodoItem;
+import boardcafe.boardpractice.todo.application.response.TodosResponse;
+import boardcafe.boardpractice.todo.domain.Todo;
+import boardcafe.boardpractice.todo.domain.repository.TodoRepository;
+import boardcafe.boardpractice.todo.exception.TodoNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+
+    public TodosResponse getAllTodos() {
+        final List<Todo> todos = todoRepository.findByDeletedFalse();
+        return new TodosResponse(todos.stream()
+                .map(TodoItem::of)
+                .toList());
+    }
+
+    @Transactional
+    public TodoItem save(TodoCreateServiceRequest request) {
+        final Todo todo = todoRepository.save(new Todo(request.content()));
+        return TodoItem.of(todo);
+    }
+
+    @Transactional
+    public void updateTodoCompleted(final Long todoId) {
+        final Todo todo = todoRepository.findByIdAndDeletedFalse(todoId)
+                .orElseThrow(() -> new TodoNotFoundException(NOT_FOUND_TODO_ID));
+        todo.updateCompleted();
+    }
+
+    @Transactional
+    public void delete(final Long todoId) {
+        final Todo todo = todoRepository.findByIdAndDeletedFalse(todoId)
+                .orElseThrow(() -> new TodoNotFoundException(NOT_FOUND_TODO_ID));
+        todo.removeTodo();
+    }
+}
+

--- a/src/main/java/boardcafe/boardpractice/todo/application/request/TodoCreateServiceRequest.java
+++ b/src/main/java/boardcafe/boardpractice/todo/application/request/TodoCreateServiceRequest.java
@@ -1,0 +1,4 @@
+package boardcafe.boardpractice.todo.application.request;
+
+public record TodoCreateServiceRequest(String content) {
+}

--- a/src/main/java/boardcafe/boardpractice/todo/application/response/TodoItem.java
+++ b/src/main/java/boardcafe/boardpractice/todo/application/response/TodoItem.java
@@ -1,0 +1,10 @@
+package boardcafe.boardpractice.todo.application.response;
+
+import boardcafe.boardpractice.todo.domain.Todo;
+
+public record TodoItem(Long id, String content, boolean completed) {
+
+    public static TodoItem of(Todo todo) {
+        return new TodoItem(todo.getId(), todo.getContent(), todo.getCompleted());
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/todo/application/response/TodosResponse.java
+++ b/src/main/java/boardcafe/boardpractice/todo/application/response/TodosResponse.java
@@ -1,0 +1,6 @@
+package boardcafe.boardpractice.todo.application.response;
+
+import java.util.List;
+
+public record TodosResponse(List<TodoItem> todos) {
+}

--- a/src/main/java/boardcafe/boardpractice/todo/domain/Todo.java
+++ b/src/main/java/boardcafe/boardpractice/todo/domain/Todo.java
@@ -1,0 +1,42 @@
+package boardcafe.boardpractice.todo.domain;
+
+import boardcafe.boardpractice.common.auditing.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Todo extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    private Boolean completed = Boolean.FALSE;
+
+    private Boolean deleted = Boolean.FALSE;
+
+    public Todo(final String content) {
+        this.content = content;
+    }
+
+    public void updateCompleted() {
+        this.completed = !completed;
+    }
+
+    public void removeTodo() {
+        this.deleted = true;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/boardcafe/boardpractice/todo/domain/repository/TodoRepository.java
@@ -1,0 +1,14 @@
+package boardcafe.boardpractice.todo.domain.repository;
+
+import boardcafe.boardpractice.todo.domain.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+    List<Todo> findByDeletedFalse();
+    Optional<Todo> findByIdAndDeletedFalse(Long id);
+}

--- a/src/main/java/boardcafe/boardpractice/todo/exception/TodoNotFoundException.java
+++ b/src/main/java/boardcafe/boardpractice/todo/exception/TodoNotFoundException.java
@@ -1,0 +1,14 @@
+package boardcafe.boardpractice.todo.exception;
+
+import boardcafe.boardpractice.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TodoNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public TodoNotFoundException(final ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/todo/presentation/TodoController.java
+++ b/src/main/java/boardcafe/boardpractice/todo/presentation/TodoController.java
@@ -1,0 +1,42 @@
+package boardcafe.boardpractice.todo.presentation;
+
+import boardcafe.boardpractice.todo.application.TodoService;
+import boardcafe.boardpractice.todo.application.response.TodoItem;
+import boardcafe.boardpractice.todo.application.response.TodosResponse;
+import boardcafe.boardpractice.todo.presentation.request.TodoCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RestController
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @GetMapping("/todos")
+    public ResponseEntity<TodosResponse> getTodos() {
+        return ResponseEntity.ok().body(todoService.getAllTodos());
+    }
+
+    @PostMapping("/todos")
+    public ResponseEntity<TodoItem> createTodo(@Valid @RequestBody TodoCreateRequest todoCreateRequest) {
+        final TodoItem todoItem = todoService.save(todoCreateRequest.toServiceRequest());
+        return ResponseEntity.created(URI.create("/todos/" + todoItem.id())).body(todoItem);
+    }
+
+    @PatchMapping("/todos/{todoId}")
+    public ResponseEntity<Void> updateCompleted(@PathVariable Long todoId) {
+        todoService.updateTodoCompleted(todoId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/todos/{todoId}")
+    public ResponseEntity<Void> deleteTodo(@PathVariable Long todoId) {
+        todoService.delete(todoId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/todo/presentation/request/TodoCreateRequest.java
+++ b/src/main/java/boardcafe/boardpractice/todo/presentation/request/TodoCreateRequest.java
@@ -1,0 +1,13 @@
+package boardcafe.boardpractice.todo.presentation.request;
+
+import boardcafe.boardpractice.todo.application.request.TodoCreateServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+
+public record TodoCreateRequest(
+        @NotBlank(message = "해야 할 일을 필수로 입력해야 합니다.")
+        String content
+) {
+    public TodoCreateServiceRequest toServiceRequest() {
+        return new TodoCreateServiceRequest(content);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,52 @@
+spring:
+  profiles:
+    default: local
+
+  datasource:
+    url: jdbc:h2:mem:~/BoardPracticeApplication
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+    defer-datasource-initialization: true
+
+  h2:
+    console:
+      enabled: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
## 🚀 todo 생성 조회 수정 삭제 api 구현
## 📸 #3
- close #3
- todo 기본 crud 기능 구현했습니다.
- 안쪽 계층에서 바깥쪽 계층으로 의존성이 생기지 않도록 설계를 했습니다.
- 서비스 계층과 컨트롤러 계층 사이에 dto 객체를 따로 만들어 주었고 패키지도 분리해주었습니다.
- sandbox와 요청 주고받을 수 있도록 cors 설정 해주었습니다.
