### PR TITLE
feat: #22 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+application-secret.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,12 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/boardcafe/boardpractice/article/application/ArticleService.java
+++ b/src/main/java/boardcafe/boardpractice/article/application/ArticleService.java
@@ -5,10 +5,9 @@ import boardcafe.boardpractice.article.application.response.ArticleResponse;
 import boardcafe.boardpractice.article.application.response.ArticlesCursorResponse;
 import boardcafe.boardpractice.article.application.response.ArticlesOffsetResponse;
 import boardcafe.boardpractice.article.domain.Article;
+import boardcafe.boardpractice.article.domain.repository.ArticleCustomRepository;
 import boardcafe.boardpractice.article.domain.repository.ArticleRepository;
-import boardcafe.boardpractice.article.infrastructure.ArticleJdbcRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ public class ArticleService {
     private static final String DEFAULT_SORT_FIELD = "articleNo";
 
     private final ArticleRepository articleRepository;
-    private final ArticleJdbcRepository articleJdbcRepository;
 
     public ArticlesOffsetResponse getAllArticlesWithOffset(final Pageable pageable) {
         final Page<Article> articles = articleRepository.findAll(pageable.previousOrFirst());
@@ -41,7 +39,7 @@ public class ArticleService {
         final List<Article> articles = requests.stream()
             .map(request -> new Article(request.articleNo(), request.title()))
             .toList();
-        articleJdbcRepository.saveAll(articles);
+        articleRepository.saveAllInBatch(articles);
     }
 
     private ArticlesOffsetResponse getArticlesOffsetResponse(final Page<Article> page) {

--- a/src/main/java/boardcafe/boardpractice/article/domain/repository/ArticleCustomRepository.java
+++ b/src/main/java/boardcafe/boardpractice/article/domain/repository/ArticleCustomRepository.java
@@ -1,0 +1,10 @@
+package boardcafe.boardpractice.article.domain.repository;
+
+import boardcafe.boardpractice.article.domain.Article;
+
+import java.util.List;
+
+public interface ArticleCustomRepository {
+
+    void saveAllInBatch(List<Article> articles);
+}

--- a/src/main/java/boardcafe/boardpractice/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/boardcafe/boardpractice/article/domain/repository/ArticleRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleCustomRepository {
 
     Slice<Article> findAllBy(final Pageable pageable);
 

--- a/src/main/java/boardcafe/boardpractice/article/infrastructure/ArticleRepositoryImpl.java
+++ b/src/main/java/boardcafe/boardpractice/article/infrastructure/ArticleRepositoryImpl.java
@@ -18,13 +18,13 @@ public class ArticleRepositoryImpl implements ArticleCustomRepository {
     private final JdbcTemplate jdbcTemplate;
 
     @Override
-    public void saveAllInBatch(List<Article> articles) {
-        String sql = "insert into article (article_no, title, created_at, modified_at) values(?,?, now(), now())";
+    public void saveAllInBatch(final List<Article> articles) {
+        final String sql = "insert into article (article_no, title, created_at, modified_at) values(?,?, now(), now())";
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
 
             @Override
             public void setValues(final PreparedStatement ps, final int i) throws SQLException {
-                Article article = articles.get(i);
+                final Article article = articles.get(i);
                 ps.setLong(1, article.getArticleNo());
                 ps.setString(2, article.getTitle());
             }

--- a/src/main/java/boardcafe/boardpractice/article/infrastructure/ArticleRepositoryImpl.java
+++ b/src/main/java/boardcafe/boardpractice/article/infrastructure/ArticleRepositoryImpl.java
@@ -1,6 +1,7 @@
 package boardcafe.boardpractice.article.infrastructure;
 
 import boardcafe.boardpractice.article.domain.Article;
+import boardcafe.boardpractice.article.domain.repository.ArticleCustomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -12,11 +13,12 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Repository
-public class ArticleJdbcRepository {
+public class ArticleRepositoryImpl implements ArticleCustomRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public void saveAll(List<Article> articles) {
+    @Override
+    public void saveAllInBatch(List<Article> articles) {
         String sql = "insert into article (article_no, title, created_at, modified_at) values(?,?, now(), now())";
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
 

--- a/src/main/java/boardcafe/boardpractice/auth/application/AccessTokenResponse.java
+++ b/src/main/java/boardcafe/boardpractice/auth/application/AccessTokenResponse.java
@@ -1,0 +1,4 @@
+package boardcafe.boardpractice.auth.application;
+
+public record AccessTokenResponse(String accessToken) {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/application/AuthService.java
+++ b/src/main/java/boardcafe/boardpractice/auth/application/AuthService.java
@@ -1,0 +1,60 @@
+package boardcafe.boardpractice.auth.application;
+
+import boardcafe.boardpractice.auth.exception.InvalidTokenException;
+import boardcafe.boardpractice.auth.infrastructure.OAuthProvider;
+import boardcafe.boardpractice.auth.infrastructure.OAuthUserInfo;
+import boardcafe.boardpractice.auth.domain.RefreshToken;
+import boardcafe.boardpractice.auth.domain.repository.RefreshTokenRepository;
+import boardcafe.boardpractice.auth.infrastructure.JwtProvider;
+import boardcafe.boardpractice.member.domain.Member;
+import boardcafe.boardpractice.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+    private final OAuthProvider provider;
+
+    @Transactional
+    public AuthToken login(final String code, LocalDateTime time) {
+        final OAuthUserInfo userInfo = provider.getOAuthUserInfo(code);
+        final Member member = findOrCreateMember(userInfo);
+        member.updateLoginDate(time);
+        final AuthToken authToken = jwtProvider.generateAccessAndRefreshToken(member.getId().toString());
+        saveRefreshToken(authToken, member);
+        return authToken;
+    }
+
+    public AccessTokenResponse renewalAccessToken(final String refreshToken) {
+        jwtProvider.validateRefreshToken(refreshToken);
+        final String memberId = refreshTokenRepository.findById(refreshToken)
+            .orElseThrow(() -> new InvalidTokenException(INVALID_REFRESH_TOKEN))
+            .getMemberId().toString();
+        return new AccessTokenResponse(jwtProvider.generateAccessToken(memberId));
+    }
+
+    private Member findOrCreateMember(final OAuthUserInfo userInfo) {
+        return memberRepository.findByUserId(userInfo.getUserId())
+            .orElseGet(() -> memberRepository.save(userInfo.toMember()));
+    }
+
+    private void saveRefreshToken(final AuthToken authToken, final Member member) {
+        final RefreshToken refreshToken = new RefreshToken(authToken.refreshToken(), member.getId());
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    public void removeRefreshToken(final String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/application/AuthToken.java
+++ b/src/main/java/boardcafe/boardpractice/auth/application/AuthToken.java
@@ -1,0 +1,7 @@
+package boardcafe.boardpractice.auth.application;
+
+public record AuthToken(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/domain/RefreshToken.java
+++ b/src/main/java/boardcafe/boardpractice/auth/domain/RefreshToken.java
@@ -1,0 +1,20 @@
+package boardcafe.boardpractice.auth.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 3600)
+public class RefreshToken {
+
+    @Id
+    private String token;
+
+    private Long memberId;
+
+    public RefreshToken(final String token, final Long memberId) {
+        this.token = token;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/boardcafe/boardpractice/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package boardcafe.boardpractice.auth.domain.repository;
+
+import boardcafe.boardpractice.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/exception/AuthException.java
+++ b/src/main/java/boardcafe/boardpractice/auth/exception/AuthException.java
@@ -1,0 +1,14 @@
+package boardcafe.boardpractice.auth.exception;
+
+import boardcafe.boardpractice.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AuthException(final ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/exception/ExpiredTokenException.java
+++ b/src/main/java/boardcafe/boardpractice/auth/exception/ExpiredTokenException.java
@@ -1,0 +1,10 @@
+package boardcafe.boardpractice.auth.exception;
+
+import boardcafe.boardpractice.common.exception.ErrorCode;
+
+public class ExpiredTokenException extends AuthException {
+
+    public ExpiredTokenException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/exception/InvalidTokenException.java
+++ b/src/main/java/boardcafe/boardpractice/auth/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package boardcafe.boardpractice.auth.exception;
+
+import boardcafe.boardpractice.common.exception.ErrorCode;
+
+public class InvalidTokenException extends AuthException {
+
+    public InvalidTokenException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/JwtProvider.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/JwtProvider.java
@@ -1,0 +1,93 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import boardcafe.boardpractice.auth.application.AuthToken;
+import boardcafe.boardpractice.auth.exception.ExpiredTokenException;
+import boardcafe.boardpractice.auth.exception.InvalidTokenException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final Long accessTokenExpTime;
+    private final Long refreshTokenExpTime;
+
+    public JwtProvider(
+        @Value("${security.jwt.token.secret-key}") final String secretKey,
+        @Value("${security.jwt.token.access-expiration-time}") final Long accessTokenExpTime,
+        @Value("${security.jwt.token.refresh-expiration-time}") final Long refreshTokenExpTime
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(UTF_8));
+        this.accessTokenExpTime = Long.valueOf(accessTokenExpTime);
+        this.refreshTokenExpTime = Long.valueOf(refreshTokenExpTime);
+    }
+
+    public AuthToken generateAccessAndRefreshToken(final String subject) {
+        return new AuthToken(
+            generateAccessToken(subject),
+            generateRefreshToken(subject)
+        );
+    }
+
+    public String generateAccessToken(final String subject) {
+        return generateToken(subject, accessTokenExpTime);
+    }
+
+    private String generateRefreshToken(final String subject) {
+        return generateToken(subject, refreshTokenExpTime);
+    }
+
+    public void validateAccessToken(final String accessToken) {
+        try {
+            parseToken(accessToken);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException(EXPIRED_ACCESS_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException(INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public void validateRefreshToken(final String refreshToken) {
+        try {
+            parseToken(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException(EXPIRED_REFRESH_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException(INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private String generateToken(final String subject, final Long validityInMilliseconds) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+            .subject(subject)
+            .issuedAt(new Date())
+            .expiration(validity)
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public String getSubject(final String token) {
+        return parseToken(token)
+            .getPayload()
+            .getSubject();
+    }
+
+    private Jws<Claims> parseToken(final String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoAccount.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoAccount.java
@@ -1,0 +1,21 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class KakaoAccount {
+
+    @JsonProperty("profile")
+    private KakaoProfile profile;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("email")
+    private String email;
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoOAuthProvider.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoOAuthProvider.java
@@ -1,0 +1,60 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import boardcafe.boardpractice.auth.exception.AuthException;
+import boardcafe.boardpractice.common.client.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Optional;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.FAIL_OAUTH_USERINFO_RETRIEVAL;
+import static boardcafe.boardpractice.common.exception.ErrorCode.INVALID_AUTHORIZATION_CODE;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+
+@RequiredArgsConstructor
+@Component
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    private final RestClient restClient;
+    private final KakaoProperties properties;
+
+    @Override
+    public OAuthUserInfo getOAuthUserInfo(final String code) {
+        final String accessToken = requestKakaoAccessToken(code);
+        final ResponseEntity<KakaoOAuthUserInfo> response = restClient.get()
+            .uri(properties.getInfoUrl())
+            .header(AUTHORIZATION, "Bearer " + accessToken)
+            .retrieve()
+            .toEntity(KakaoOAuthUserInfo.class);
+
+        if(response.getStatusCode().is2xxSuccessful()) {
+            return response.getBody();
+        }
+        throw new AuthException(FAIL_OAUTH_USERINFO_RETRIEVAL);
+    }
+
+    private String requestKakaoAccessToken(final String code) {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("grant_type", properties.getGrantType());
+        params.add("client_id", properties.getClientId());
+        params.add("redirect_uri", properties.getRedirectUri());
+        params.add("client_secret", properties.getClientSecret());
+
+        final ResponseEntity<OAuthAccessTokenResponse> response = restClient.post()
+            .uri(properties.getTokenUrl())
+            .contentType(APPLICATION_FORM_URLENCODED)
+            .body(params)
+            .retrieve()
+            .toEntity(OAuthAccessTokenResponse.class);
+
+        return Optional.ofNullable(response.getBody())
+            .orElseThrow(() -> new AuthException(INVALID_AUTHORIZATION_CODE))
+            .accessToken();
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoOAuthUserInfo.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoOAuthUserInfo.java
@@ -1,0 +1,52 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import boardcafe.boardpractice.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class KakaoOAuthUserInfo implements OAuthUserInfo {
+
+    @JsonProperty("id")
+    private Long userId;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount account;
+
+    @Override
+    public Long getUserId() {
+        return userId;
+    }
+
+    @Override
+    public String getNickname() {
+        return account.getProfile().getNickname();
+    }
+
+    @Override
+    public String getImageUrl() {
+        return account.getProfile().getImageUrl();
+    }
+
+    @Override
+    public String getName() {
+        return account.getName();
+    }
+
+    @Override
+    public String getEmail() {
+        return account.getEmail();
+    }
+
+    public Member toMember() {
+        return Member.builder()
+            .nickname(getNickname())
+            .name(getName())
+            .email(getEmail())
+            .userId(userId)
+            .imageUrl(getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoProfile.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/KakaoProfile.java
@@ -1,0 +1,18 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class KakaoProfile {
+
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("profile_image_url")
+    private String imageUrl;
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthAccessTokenResponse.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthAccessTokenResponse.java
@@ -1,0 +1,9 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OAuthAccessTokenResponse(
+    @JsonProperty("access_token")
+    String accessToken
+) {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthProvider.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthProvider.java
@@ -1,0 +1,6 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+public interface OAuthProvider {
+
+    OAuthUserInfo getOAuthUserInfo(String code);
+}

--- a/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthUserInfo.java
+++ b/src/main/java/boardcafe/boardpractice/auth/infrastructure/OAuthUserInfo.java
@@ -1,0 +1,13 @@
+package boardcafe.boardpractice.auth.infrastructure;
+
+import boardcafe.boardpractice.member.domain.Member;
+
+public interface OAuthUserInfo {
+
+    Long getUserId();
+    String getNickname();
+    String getImageUrl();
+    String getName();
+    String getEmail();
+    Member toMember();
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/AuthController.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/AuthController.java
@@ -1,0 +1,70 @@
+package boardcafe.boardpractice.auth.presentation;
+
+import boardcafe.boardpractice.auth.application.AccessTokenResponse;
+import boardcafe.boardpractice.auth.application.AuthService;
+import boardcafe.boardpractice.auth.application.AuthToken;
+import boardcafe.boardpractice.member.application.MemberService;
+import boardcafe.boardpractice.auth.presentation.request.LoginMember;
+import boardcafe.boardpractice.auth.presentation.request.TokenRequest;
+import boardcafe.boardpractice.member.application.response.MemberNicknameResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static java.time.LocalDateTime.*;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+    private final MemberService memberService;
+
+    @PostMapping("/auth")
+    public ResponseEntity<AccessTokenResponse> generateAccessAndRefreshToken(
+        @Valid @RequestBody final TokenRequest tokenRequest
+    ) {
+        final AuthToken authToken = authService.login(tokenRequest.code(), now());
+        final ResponseCookie cookie = ResponseCookie.from("refreshToken", authToken.refreshToken())
+            .maxAge(3600)
+            .httpOnly(true)
+            .sameSite("none")
+            .secure(true)
+            .build();
+
+        return ResponseEntity.status(CREATED)
+            .header(SET_COOKIE, cookie.toString())
+            .body(new AccessTokenResponse(authToken.accessToken()));
+    }
+
+    @GetMapping("/member")
+    public ResponseEntity<MemberNicknameResponse> getMemberNickname(
+        @AuthenticationPrincipal final LoginMember loginMember
+    ) {
+        return ResponseEntity.status(OK)
+            .body(memberService.getNicknameById(loginMember.memberId()));
+    }
+
+    @GetMapping("/reissue")
+    public ResponseEntity<AccessTokenResponse> reissueAccessToken(
+        @CookieValue("refreshToken") final String refreshToken
+    ) {
+        return ResponseEntity.status(CREATED)
+            .body(authService.renewalAccessToken(refreshToken));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @AuthenticationPrincipal final LoginMember loginMember,
+        @CookieValue("refreshToken") final String refreshToken
+    ) {
+        authService.removeRefreshToken(refreshToken);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/AuthenticationPrincipal.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package boardcafe.boardpractice.auth.presentation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface AuthenticationPrincipal {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,44 @@
+package boardcafe.boardpractice.auth.presentation;
+
+import boardcafe.boardpractice.auth.application.AuthService;
+import boardcafe.boardpractice.auth.infrastructure.JwtProvider;
+import boardcafe.boardpractice.auth.presentation.request.LoginMember;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthorizationTokenExtractor extractor;
+    private final JwtProvider jwtProvider;
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        final MethodParameter parameter,
+        final ModelAndViewContainer mavContainer,
+        final NativeWebRequest webRequest,
+        final WebDataBinderFactory binderFactory
+    ) {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final String authorizationHeader = request.getHeader(AUTHORIZATION);
+        final String accessToken = extractor.extract(authorizationHeader);
+        jwtProvider.validateAccessToken(accessToken);
+        final Long memberId = Long.valueOf(jwtProvider.getSubject(accessToken));
+        return new LoginMember(memberId);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/AuthorizationTokenExtractor.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/AuthorizationTokenExtractor.java
@@ -1,0 +1,19 @@
+package boardcafe.boardpractice.auth.presentation;
+
+import boardcafe.boardpractice.common.exception.BadRequestException;
+import org.springframework.stereotype.Component;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.INVALID_REQUEST;
+
+@Component
+public class AuthorizationTokenExtractor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+
+    public String extract(String authorizationHeader) {
+        if(authorizationHeader != null && authorizationHeader.startsWith(BEARER_TYPE)) {
+            return authorizationHeader.substring(BEARER_TYPE.length()).trim();
+        }
+        throw new BadRequestException(INVALID_REQUEST);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/request/LoginMember.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/request/LoginMember.java
@@ -1,0 +1,4 @@
+package boardcafe.boardpractice.auth.presentation.request;
+
+public record LoginMember(Long memberId) {
+}

--- a/src/main/java/boardcafe/boardpractice/auth/presentation/request/TokenRequest.java
+++ b/src/main/java/boardcafe/boardpractice/auth/presentation/request/TokenRequest.java
@@ -1,0 +1,9 @@
+package boardcafe.boardpractice.auth.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRequest(
+    @NotBlank(message = "인가 코드는 필수값입니다.")
+    String code
+) {
+}

--- a/src/main/java/boardcafe/boardpractice/common/client/ClientConfig.java
+++ b/src/main/java/boardcafe/boardpractice/common/client/ClientConfig.java
@@ -1,0 +1,16 @@
+package boardcafe.boardpractice.common.client;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@EnableConfigurationProperties(KakaoProperties.class)
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/client/KakaoProperties.java
+++ b/src/main/java/boardcafe/boardpractice/common/client/KakaoProperties.java
@@ -1,0 +1,34 @@
+package boardcafe.boardpractice.common.client;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties(prefix = "oauth")
+public class KakaoProperties {
+
+    private final String grantType;
+    private final String clientId;
+    private final String redirectUri;
+    private final String clientSecret;
+    private final String tokenUrl;
+    private final String infoUrl;
+
+    @ConstructorBinding
+    public KakaoProperties(
+        final String grantType,
+        final String clientId,
+        final String redirectUri,
+        final String clientSecret,
+        final String tokenUrl,
+        final String infoUrl
+    ) {
+        this.grantType = grantType;
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        this.clientSecret = clientSecret;
+        this.tokenUrl = tokenUrl;
+        this.infoUrl = infoUrl;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/exception/ErrorCode.java
+++ b/src/main/java/boardcafe/boardpractice/common/exception/ErrorCode.java
@@ -13,13 +13,16 @@ public enum ErrorCode {
     INVALID_REQUEST(1000, BAD_REQUEST, "올바르지 않은 요청입니다."),
     INVALID_IMAGE_FORMAT(1001, BAD_REQUEST, "지원하지 않는 이미지 형식입니다."),
     EXCEED_IMAGE_CAPACITY(1002, BAD_REQUEST, "이미지 크기가 허용된 최대 용량을 초과했습니다."),
+    FAIL_IMAGE_UPLOAD(1003, BAD_REQUEST, "이미지 업로드에 실패했습니다."),
 
     INVALID_AUTHORITY(2001, FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다."),
     INVALID_PASSWORD(2002, UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     INVALID_ACCESS_TOKEN(2003, UNAUTHORIZED, "유효하지 않은 AccessToken 입니다."),
     INVALID_REFRESH_TOKEN(2004, UNAUTHORIZED, "유효하지 않은 RefreshToken 입니다."),
-    EXPIRED_ACCESS_TOKEN(2005, UNAUTHORIZED, "만료된 AccessToken 입니다."),
-    EXPIRED_REFRESH_TOKEN(2006, UNAUTHORIZED, "만료된 RefreshToken 입니다."),
+    INVALID_AUTHORIZATION_CODE(2005, UNAUTHORIZED, "유효하지 않은 인가 코드 입니다."),
+    EXPIRED_ACCESS_TOKEN(2006, UNAUTHORIZED, "만료된 AccessToken 입니다."),
+    EXPIRED_REFRESH_TOKEN(2007, UNAUTHORIZED, "만료된 RefreshToken 입니다."),
+    FAIL_OAUTH_USERINFO_RETRIEVAL(2008, UNAUTHORIZED, "회원 정보를 가져오는데 실패했습니다."),
 
     NOT_FOUND_TODO_ID(3001, NOT_FOUND, "요청한 ID에 해당하는 게시물이 존재하지 않습니다."),
     NOT_FOUND_USER_ID(3002, NOT_FOUND, "요청한 ID에 해당하는 사용자가 존재하지 않습니다."),

--- a/src/main/java/boardcafe/boardpractice/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/boardcafe/boardpractice/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,12 @@
 package boardcafe.boardpractice.common.exception;
 
+import boardcafe.boardpractice.auth.exception.AuthException;
+import boardcafe.boardpractice.member.exception.UserNotFoundException;
 import boardcafe.boardpractice.todo.exception.TodoNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -23,39 +24,60 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
-            final MethodArgumentNotValidException e,
-            final HttpHeaders headers,
-            final HttpStatusCode status,
-            final WebRequest request
+        final MethodArgumentNotValidException e,
+        final HttpHeaders headers,
+        final HttpStatusCode status,
+        final WebRequest request
     ) {
         log.warn(e.getMessage(), e);
         String errorMessage = e.getBindingResult().getAllErrors().getFirst().getDefaultMessage();
         return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(INVALID_REQUEST, errorMessage));
+            .body(new ExceptionResponse(INVALID_REQUEST, errorMessage));
     }
 
     @ExceptionHandler(TodoNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleTodoNotFoundException(final TodoNotFoundException e) {
         log.warn(e.getMessage(), e);
         return ResponseEntity.status(NOT_FOUND)
-                .body(new ExceptionResponse(e.getErrorCode()));
+            .body(new ExceptionResponse(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleUserNotFoundException(final UserNotFoundException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.status(NOT_FOUND)
+            .body(new ExceptionResponse(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthException(final AuthException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.badRequest()
+            .body(new ExceptionResponse(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
+        log.warn(e.getMessage(), e);
+        return ResponseEntity.badRequest()
+            .body(new ExceptionResponse(e.getErrorCode()));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ExceptionResponse> handleConstraintViolationException(final ConstraintViolationException e) {
         log.warn(e.getMessage(), e);
         String errorMessage = e.getConstraintViolations().stream()
-                .map(ConstraintViolation::getMessage)
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("메시지 추출 도중 에러 발생"));
+            .map(ConstraintViolation::getMessage)
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("메시지 추출 도중 에러 발생"));
         return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(INVALID_REQUEST, errorMessage));
+            .body(new ExceptionResponse(INVALID_REQUEST, errorMessage));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.internalServerError()
-                .body(new ExceptionResponse(SERVER_ERROR));
+            .body(new ExceptionResponse(SERVER_ERROR));
     }
 }

--- a/src/main/java/boardcafe/boardpractice/common/logging/LoggingConfig.java
+++ b/src/main/java/boardcafe/boardpractice/common/logging/LoggingConfig.java
@@ -1,0 +1,17 @@
+package boardcafe.boardpractice.common.logging;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoggingConfig {
+
+    @Bean
+    public RequestLoggingFilter requestLoggingFilter() {
+        final RequestLoggingFilter filter = new RequestLoggingFilter();
+        filter.setIncludeQueryString(true);
+        filter.setIncludePayload(true);
+        filter.setMaxPayloadLength(500);
+        return filter;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/logging/MdcFilter.java
+++ b/src/main/java/boardcafe/boardpractice/common/logging/MdcFilter.java
@@ -1,0 +1,33 @@
+package boardcafe.boardpractice.common.logging;
+
+import jakarta.servlet.*;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+@Component
+@Order(HIGHEST_PRECEDENCE)
+public class MdcFilter implements Filter {
+
+    private static final String CORRELATION_ID = "CORRELATION_ID";
+
+    @Override
+    public void doFilter(
+        final ServletRequest request,
+        final ServletResponse response,
+        final FilterChain chain
+    ) throws IOException, ServletException {
+        MDC.put(CORRELATION_ID, generateCorrelationId());
+        chain.doFilter(request, response);
+        MDC.clear();
+    }
+
+    private String generateCorrelationId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/logging/RequestLoggingFilter.java
+++ b/src/main/java/boardcafe/boardpractice/common/logging/RequestLoggingFilter.java
@@ -1,0 +1,18 @@
+package boardcafe.boardpractice.common.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.AbstractRequestLoggingFilter;
+
+@Slf4j
+public class RequestLoggingFilter extends AbstractRequestLoggingFilter {
+
+    @Override
+    protected void beforeRequest(final HttpServletRequest request, final String message) {
+        log.info(message);
+    }
+
+    @Override
+    protected void afterRequest(final HttpServletRequest request, final String message) {
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/redis/RedisConfig.java
+++ b/src/main/java/boardcafe/boardpractice/common/redis/RedisConfig.java
@@ -1,0 +1,24 @@
+package boardcafe.boardpractice.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/common/resolver/ResolverConfig.java
+++ b/src/main/java/boardcafe/boardpractice/common/resolver/ResolverConfig.java
@@ -1,0 +1,23 @@
+package boardcafe.boardpractice.common.resolver;
+
+import boardcafe.boardpractice.auth.presentation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class ResolverConfig implements WebMvcConfigurer {
+
+    private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    public ResolverConfig(final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver) {
+        this.authenticationPrincipalArgumentResolver = authenticationPrincipalArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authenticationPrincipalArgumentResolver);
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/member/application/MemberService.java
+++ b/src/main/java/boardcafe/boardpractice/member/application/MemberService.java
@@ -1,0 +1,23 @@
+package boardcafe.boardpractice.member.application;
+
+import boardcafe.boardpractice.member.application.response.MemberNicknameResponse;
+import boardcafe.boardpractice.member.domain.repository.MemberRepository;
+import boardcafe.boardpractice.member.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static boardcafe.boardpractice.common.exception.ErrorCode.NOT_FOUND_USER_ID;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberNicknameResponse getNicknameById(final Long memberId) {
+        return memberRepository.findNicknameById(memberId)
+            .orElseThrow(() -> new UserNotFoundException(NOT_FOUND_USER_ID));
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/member/application/response/MemberNicknameResponse.java
+++ b/src/main/java/boardcafe/boardpractice/member/application/response/MemberNicknameResponse.java
@@ -1,0 +1,4 @@
+package boardcafe.boardpractice.member.application.response;
+
+public record MemberNicknameResponse(String nickname) {
+}

--- a/src/main/java/boardcafe/boardpractice/member/domain/Member.java
+++ b/src/main/java/boardcafe/boardpractice/member/domain/Member.java
@@ -1,0 +1,64 @@
+package boardcafe.boardpractice.member.domain;
+
+import boardcafe.boardpractice.common.auditing.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static boardcafe.boardpractice.member.domain.MemberStatus.ACTIVE;
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.time.LocalDateTime.*;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String name;
+
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    private String imageUrl;
+
+    @Enumerated(STRING)
+    private MemberStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime lastLogin;
+
+    @Builder
+    public Member(
+        final String nickname,
+        final String name,
+        final String email,
+        final Long userId,
+        final String imageUrl
+    ) {
+        this.nickname = nickname;
+        this.name = name;
+        this.email = email;
+        this.userId = userId;
+        this.imageUrl = imageUrl;
+        this.status = ACTIVE;
+        this.lastLogin = now();
+    }
+
+    public void updateLoginDate(LocalDateTime loginDateTime) {
+        this.lastLogin = loginDateTime;
+    }
+}

--- a/src/main/java/boardcafe/boardpractice/member/domain/MemberStatus.java
+++ b/src/main/java/boardcafe/boardpractice/member/domain/MemberStatus.java
@@ -1,0 +1,8 @@
+package boardcafe.boardpractice.member.domain;
+
+public enum MemberStatus {
+
+    ACTIVE,
+    DELETED,
+    DORMANT
+}

--- a/src/main/java/boardcafe/boardpractice/member/domain/repository/MemberRepository.java
+++ b/src/main/java/boardcafe/boardpractice/member/domain/repository/MemberRepository.java
@@ -1,0 +1,18 @@
+package boardcafe.boardpractice.member.domain.repository;
+
+import boardcafe.boardpractice.member.application.response.MemberNicknameResponse;
+import boardcafe.boardpractice.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("select m from Member m where m.userId = :userId and m.status != 'DELETED'")
+    Optional<Member> findByUserId(final Long userId);
+
+    @Query("select new boardcafe.boardpractice.member.application.response.MemberNicknameResponse" +
+        "(m.nickname) from Member m where m.id = :memberId and m.status = 'ACTIVE'")
+    Optional<MemberNicknameResponse> findNicknameById(final Long memberId);
+}

--- a/src/main/java/boardcafe/boardpractice/member/exception/UserNotFoundException.java
+++ b/src/main/java/boardcafe/boardpractice/member/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package boardcafe.boardpractice.member.exception;
+
+import boardcafe.boardpractice.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public UserNotFoundException(final ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   profiles:
     default: local
+  config:
+    import: application-secret.yml
 
   datasource:
     url: jdbc:h2:mem:~/BoardPracticeApplication
@@ -11,6 +13,17 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 ---
 spring:
@@ -58,4 +71,3 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
-

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<included>
+    <appender name="console-appender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%highlight(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{CORRELATION_ID})][%highlight(%replace(%logger{20}){'\\w\\.', ''})] %msg %n</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-appender.xml
+++ b/src/main/resources/file-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="file-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>[%highlight(%level)][%d{MM-dd HH:mm:ss}][%magenta(%8X{CORRELATION_ID})][%highlight(%replace(%logger{20}){'\\w\\.', ''})] %msg %n</pattern>
+            <charset>utf-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>../../board-project-logs/%d{yyyy-MM-dd}.log</fileNamePattern>
+            <totalSizeCap>2GB</totalSizeCap>
+            <maxHistory>15</maxHistory>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <include resource="console-appender.xml"/>
+    <include resource="file-appender.xml"/>
+
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="console-appender"/>
+        <appender-ref ref="file-appender"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🚀 작업 내용
- jwt와 kakao oauth을 이용해서 로그인 기능을 구현했습니다.
- mdc를 이용해서 log를 출력하고, 파일에 error가 발생한 로그들을 날짜별로 모아서 확인할 수 있도록 설정했습니다.
## 📸 이슈 번호
- close #22